### PR TITLE
Add compression byte to secp256k1 multicodec public key

### DIFF
--- a/TestVectors/keyPair.json
+++ b/TestVectors/keyPair.json
@@ -1,4 +1,4 @@
 {
-    "publicKeyMultibase": "z6DtcgBo65Ms1qzug5JAgVZH3sEpH7vp4q6D2T3cdHnyBFGj",
+    "publicKeyMultibase": "zQ3shcJDnkBjY3XqD4WVKktWQZqgQSrYzhaTo6gxcs6GXjUuM",
     "privateKeyMultibase": "z3vLhXkdoZmXj6TwZoG5D8CXvDQ4AzYeZHLusAR5RU5K56zk"
 }


### PR DESCRIPTION
This adds a 0x02 byte for compressed secp256k1 public keys.

Current value:
`z6DtcgBo65Ms1qzug5JAgVZH3sEpH7vp4q6D2T3cdHnyBFGj`
`e701dd308afec5777e13121fa72b9cc1b7cc0139715309b086c960e18fd969774eb8`

Change value in this PR:
`zQ3shcJDnkBjY3XqD4WVKktWQZqgQSrYzhaTo6gxcs6GXjUuM`
`e70102dd308afec5777e13121fa72b9cc1b7cc0139715309b086c960e18fd969774eb8`